### PR TITLE
Some refactoring and support to Org-mode 9.8 preview API

### DIFF
--- a/org-remoteimg.el
+++ b/org-remoteimg.el
@@ -38,6 +38,11 @@
 (require 'url)
 (require 'url-cache)
 
+(unless (fboundp 'image-supported-file-p)
+  ;; `image-supported-file-p' isn't available before Emacs 28
+  ;; Add alias to not break Emacs <28.
+  (defalias 'image-type-from-file-name 'image-supported-file-p))
+
 (defun org-image-update-overlay (file link &optional data-p refresh)
   "Create image overlay for FILE associtated with org-element LINK.
 If DATA-P is non-nil FILE is not a file name but a string with the image data.
@@ -79,7 +84,7 @@ This function is almost a duplicate of a part of `org-display-inline-images'."
                 (org-element-property :begin link)
                 'org-image-overlay)))
       (if (and (car-safe old) refresh)
-          (image-refresh (overlay-get (cdr old) 'display))
+          (image-flush (overlay-get (cdr old) 'display))
         (let ((image (create-image file
                                    (and (image-type-available-p 'imagemagick)
                                         width
@@ -170,7 +175,7 @@ Full credit goes to org-yt by Tobias Zawada for this function."
 
 (defun org-remoteimg--fetch-image (protocol link _description)
   "Synchronously retrieve image from cache or web"
-  (when (and (image-type-from-file-name link)
+  (when (and (image-supported-file-p link)
              (not (eq org-display-remote-inline-images 'skip)))
     (let* ((cache (eq org-display-remote-inline-images 'cache))
            (user-url-caching-setting url-automatic-caching)

--- a/org-remoteimg.el
+++ b/org-remoteimg.el
@@ -144,7 +144,7 @@ Full credit goes to org-yt by Tobias Zawada for this function."
   (when (display-graphic-p)
     (org-with-wide-buffer
      (goto-char (or beg (point-min)))
-     (when-let ((image-data-link-parameters
+     (when-let* ((image-data-link-parameters
 		 (cl-loop for link-par-entry in org-link-parameters
 			  with fun
 			  when (setq fun (plist-get (cdr link-par-entry) :image-data-fun))
@@ -174,7 +174,7 @@ Full credit goes to org-yt by Tobias Zawada for this function."
                    (overlay-put ol 'after-string description)))))))))))
 
 (defun org-remoteimg--fetch-image (protocol link _description)
-  "Synchronously retrieve image from cache or web"
+  "Synchronously retrieve image from cache or web."
   (when (and (image-supported-file-p link)
              (not (eq org-display-remote-inline-images 'skip)))
     (let* ((cache (eq org-display-remote-inline-images 'cache))
@@ -183,10 +183,10 @@ Full credit goes to org-yt by Tobias Zawada for this function."
            (silent-output (file-exists-p (url-cache-create-filename url))))
       (when cache (setq url-automatic-caching t))
       (prog1
-          (if-let (buf (url-retrieve-synchronously url
+          (if-let* ((buf (url-retrieve-synchronously url
                                                    silent-output
                                                    nil
-                                                   30))
+                                                   30)))
               (with-current-buffer buf
                 (goto-char (point-min))
                 (re-search-forward "\r?\n\r?\n" nil t)

--- a/org-remoteimg.el
+++ b/org-remoteimg.el
@@ -178,12 +178,12 @@ Full credit goes to org-yt by Tobias Zawada for this function."
   (when (and (image-supported-file-p link)
              (not (eq org-display-remote-inline-images 'skip)))
     (let* ((cache (eq org-display-remote-inline-images 'cache))
-           (user-url-caching-setting url-automatic-caching)
+           (url-automatic-caching (if cache
+                                      t
+                                    url-automatic-caching))
            (url (concat protocol ":" link))
            (silent-output (file-exists-p (url-cache-create-filename url))))
-      (when cache (setq url-automatic-caching t))
-      (prog1
-          (if-let* ((buf (url-retrieve-synchronously url
+      (if-let* ((buf (url-retrieve-synchronously url
                                                    silent-output
                                                    nil
                                                    30)))
@@ -191,10 +191,8 @@ Full credit goes to org-yt by Tobias Zawada for this function."
                 (goto-char (point-min))
                 (re-search-forward "\r?\n\r?\n" nil t)
                 (buffer-substring-no-properties (point) (point-max)))
-            (message "Download of image \"%s\" failed" link)
-            nil)
-        (when cache
-          (setq url-automatic-caching user-url-caching-setting))))))
+            (error "Download of image \"%s\" failed" link)
+            nil))))
 
 (advice-add #'org-display-inline-images :after #'org-display-user-inline-images)
 


### PR DESCRIPTION
Some cleanup and most important the support of the Org-mode 9.8 preview handler API support.

Some issues left:
- Descriptions which contain images are not handled
  - The preview function is correctly called but no data about the preview is passed
- Does Org-mode handle the scaling or is that the job of this package? I didn't handle any scaling
  as the function copied over from org-mode seem to handle it, assume the one from org-mode does it too.